### PR TITLE
Corrección del grupo de laboratorio

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -1,6 +1,6 @@
 project:
   name: 'ISPP-2024-L1-11'
-  owner: 'L1'
+  owner: 'L2'
   teamId: '11'
   identities: {}
   notifications:


### PR DESCRIPTION
Esta pull-request hace referencia a la tarea: https://github.com/Aparking/AparKing_Backend/issues/53
Realizada por: @laurolmer
Resumen: Se ha corregido el grupo de laboratorio de L1 a L2 ya que es el que realmente corresponde al grupo de tarde.