### PR TITLE
fix: login, register and logout fixed, when we login we create a new …

### DIFF
--- a/AparKing_Backend/settings.py
+++ b/AparKing_Backend/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     "apps.parking",
     "apps.payment",
     'rest_framework',
+    'rest_framework.authtoken',
     'corsheaders',
 ]
 
@@ -76,6 +77,18 @@ TEMPLATES = [
         },
     },
 ]
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication',  # <-- And here
+    ],
+}
+
+SIMPLE_JWT = {
+    'ROTATE_REFRESH_TOKENS': False,
+    'BLACKLIST_AFTER_ROTATION': False,
+    'UPDATE_LAST_LOGIN': False,
+}
 
 WSGI_APPLICATION = 'AparKing_Backend.wsgi.application'
 ASGI_APPLICATION = "AparKing_Backend.asgi.application"

--- a/apps/authentication/tests/tests.py
+++ b/apps/authentication/tests/tests.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
 from apps.authentication.models import CustomUser
 
 class AuthTestCase(APITestCase):
@@ -25,20 +26,21 @@ class AuthTestCase(APITestCase):
         data = {'password': self.password, 'email': self.email}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'success')
 
     def test_register(self):
         url = reverse('register')
         data = {'username': 'newuser', 'email': 'newuser@admin.com', 'password': 'newpassword', 'dni': '12345679Z', 'phone': '+34600000000', 'birth_date': '1990-01-01'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'success')
 
     def test_logout(self):
+        url_login = reverse('login')
         # Primero, inicia sesión
-        self.client.login(email=self.email, password=self.password)
+        data = {'password': self.password, 'email': self.email}
+        response = self.client.post(url_login, data, format='json')
         # Luego, prueba el logout
+        token = response.data.get('token')
         url = reverse('logout')
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token}')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'success')

--- a/apps/authentication/views.py
+++ b/apps/authentication/views.py
@@ -12,7 +12,7 @@ def auth_login(request) -> Response:
         user = serializer.validated_data
         Token.objects.filter(user=user).delete()
         token, created = Token.objects.get_or_create(user=user)
-        return Response({'token': token.key}, status=201)
+        return Response({'token': token.key}, status=200)
     else:
         return Response(serializer.errors, status=400)
 
@@ -23,7 +23,7 @@ def register(request) -> Response:
         user = serializer.save()
         token, created = Token.objects.get_or_create(user=user)
 
-        return Response({'token': token.key}, status=201)
+        return Response({'token': token.key}, status=200)
     else:
         return Response(serializer.errors, status=400)
 
@@ -33,5 +33,5 @@ def auth_logout(request) -> Response:
     if user.is_authenticated:
         # Invalidar cualquier token asociado con el usuario
         Token.objects.filter(user=user).delete()
-        return Response({'status': 'success'})
+        return Response(status=200)
     return Response(status=401)

--- a/apps/authentication/views.py
+++ b/apps/authentication/views.py
@@ -1,6 +1,8 @@
 from rest_framework.decorators import api_view
+from rest_framework.authtoken.models import Token
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.response import Response
-from django.contrib.auth import login, logout
+from django.contrib.auth import login, logout, authenticate
 from .serializers import LoginSerializer, RegisterSerializer
 
 @api_view(['POST'])
@@ -8,8 +10,9 @@ def auth_login(request) -> Response:
     serializer = LoginSerializer(data=request.data)
     if serializer.is_valid():
         user = serializer.validated_data
-        login(request, user)
-        return Response({'status': 'success'})
+        Token.objects.filter(user=user).delete()
+        token, created = Token.objects.get_or_create(user=user)
+        return Response({'token': token.key}, status=201)
     else:
         return Response(serializer.errors, status=400)
 
@@ -18,12 +21,17 @@ def register(request) -> Response:
     serializer = RegisterSerializer(data=request.data)
     if serializer.is_valid():
         user = serializer.save()
-        login(request, user)
-        return Response({'status': 'success'})
+        token, created = Token.objects.get_or_create(user=user)
+
+        return Response({'token': token.key}, status=201)
     else:
         return Response(serializer.errors, status=400)
 
 @api_view(['GET'])
 def auth_logout(request) -> Response:
-    logout(request)
-    return Response({'status': 'success'})
+    user = request.user
+    if user.is_authenticated:
+        # Invalidar cualquier token asociado con el usuario
+        Token.objects.filter(user=user).delete()
+        return Response({'status': 'success'})
+    return Response(status=401)

--- a/apps/parking/tests.py
+++ b/apps/parking/tests.py
@@ -2,7 +2,7 @@ from django.contrib.gis.geos import Point
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from apps.authentication.models import CustomUser
-from apps.parking.models import City, Parking, ParkingSize, ParkingType
+from apps.parking.models import City, Parking, ParkingType, Size
 
 class ParkingTestCase(APITestCase):
 
@@ -17,7 +17,13 @@ class ParkingTestCase(APITestCase):
             birth_date='1990-01-01'
         )
         
-        self.client.login(email='testuser@example.com', password='password')
+        url_login = reverse('login')
+        # Primero, inicia sesión
+        data = {'password': 'password', 'email': 'testuser@example.com'}
+        response = self.client.post(url_login, data, format='json')
+        # Luego, prueba el logout
+        token = response.data.get('token')
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token}')
         self.create_parking_url = reverse('create_parking')
 
     def tearDown(self):
@@ -27,7 +33,7 @@ class ParkingTestCase(APITestCase):
         data = {
             "latitude":"42.3851",
             "longitude":"2.2734",
-            "size": "SMALL",
+            "size": "BERLINA",
             "parking_type": "FREE",
         }
         
@@ -38,7 +44,7 @@ class ParkingTestCase(APITestCase):
     def test_assign_parking_success(self):
         parking = Parking.objects.create(
             location=Point(2.1734, 42.3851, srid=4326),
-            size=ParkingSize.SMALL,
+            size=Size.BERLINA,
             parking_type=ParkingType.FREE,
             is_assignment=False,
             notified_by=self.user
@@ -52,7 +58,7 @@ class ParkingTestCase(APITestCase):
     def test_transfer_parking_success(self):
         parking = Parking.objects.create(
             location=Point(2.1734, 42.3851, srid=4326),
-            size=ParkingSize.SMALL,
+            size=Size.BERLINA,
             parking_type=ParkingType.ASSIGNMENT,
             is_assignment=True,
             notified_by=self.user
@@ -66,7 +72,7 @@ class ParkingTestCase(APITestCase):
     def test_assign_parking_already_assigned(self):
         parking = Parking.objects.create(
             location=Point(2.1734, 42.3851, srid=4326),
-            size=ParkingSize.SMALL,
+            size=Size.BERLINA,
             parking_type=ParkingType.FREE,
             is_assignment=True,
             notified_by=self.user
@@ -79,7 +85,7 @@ class ParkingTestCase(APITestCase):
     def test_delete_parking_success(self):
         parking = Parking.objects.create(
             location=Point(2.1734, 42.3851, srid=4326),
-            size=ParkingSize.SMALL,
+            size=Size.BERLINA,
             parking_type=ParkingType.FREE,
             is_assignment=False,
             notified_by=self.user
@@ -93,14 +99,14 @@ class ParkingTestCase(APITestCase):
     def test_get_parking_near_success(self):
         Parking.objects.create(
             location=Point(2.1734, 42.3851, srid=4326),
-            size=ParkingSize.MEDIUM,
+            size=Size.BERLINA,
             parking_type=ParkingType.FREE,
             is_assignment=False,
             notified_by=self.user
         )
         Parking.objects.create(
             location=Point(2.1744, 42.3852, srid=4326),
-            size=ParkingSize.SMALL,
+            size=Size.BERLINA,
             parking_type=ParkingType.FREE,
             is_assignment=False,
             notified_by=self.user

--- a/apps/parking/views.py
+++ b/apps/parking/views.py
@@ -1,5 +1,5 @@
 from rest_framework.response import Response
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework import status
 
 from channels.layers import get_channel_layer
@@ -19,6 +19,8 @@ from apps.parking.filters import ParkingFilter
 from apps.parking.coordenates import Coordenates
 
 from django.contrib.auth.decorators import login_required
+from rest_framework.permissions import IsAuthenticated
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -50,7 +52,7 @@ def room(request, room_name):
     return render(request, "parking/room.html", {"room_name": room_name})
 
 @api_view(['POST'])
-#@login_required
+@permission_classes([IsAuthenticated])
 def get_parking_near(request: HttpRequest):
     """
     Obtiene los aparcamientos cercanos a las coordenadas proporcionadas en la solicitud.
@@ -85,7 +87,7 @@ def get_parking_near(request: HttpRequest):
     return Response(res, status=status.HTTP_200_OK)
 
 @api_view(['POST'])
-#@login_required
+@permission_classes([IsAuthenticated])
 def create_parking(request: HttpRequest):
     """
     Crea un nuevo aparcamiento y lo notifica a los usuarios cercanos.
@@ -129,7 +131,7 @@ def create_parking(request: HttpRequest):
         return Response({'error': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
 @api_view(['PUT'])
-#@login_required
+@permission_classes([IsAuthenticated])
 def assign_parking(request: HttpRequest, parking_id: int):
     """
     Asigna un aparcamiento a un usuario.
@@ -157,7 +159,7 @@ def assign_parking(request: HttpRequest, parking_id: int):
         return JsonResponse({"message": "The parking doesn't exist"}, status=404)
 
 @api_view(['PUT'])
-#@login_required
+@permission_classes([IsAuthenticated])
 def transfer_parking(request: HttpRequest, parking_id: int):
     """
     Transfiere un aparcamiento asignado a otro usuario.
@@ -183,7 +185,7 @@ def transfer_parking(request: HttpRequest, parking_id: int):
         return JsonResponse({"message": "The parking doesn't exist"}, status=404)
     
 @api_view(['DELETE'])
-#@login_required
+@permission_classes([IsAuthenticated])
 def delete_parking(request: HttpRequest, parking_id: int):
     """
     Elimina un aparcamiento.


### PR DESCRIPTION
Implementada la funcionalidad de login, logout y registro. Lo he hecho de tal forma que se genera un token nuevo cada vez que se inicia sesión o se produce un registro, en caso de logout el token se elimina para invalidar futuras peticiones con dicho token.
[Aparking.postman_collection.json](https://github.com/Aparking/AparKing_Backend/files/14724720/Aparking.postman_collection.json)
Podéis probar las consultas con esta colección de postman.
En caso de querer proteger una ruta solo debéis de emplear:

from rest_framework.decorators import api_view, permission_classes
from rest_framework.permissions import IsAuthenticated
En el método ->  @permission_classes([IsAuthenticated])

De ahora en adelante todos los test cuya ruta deba estar protegida deberán hacer el login en el setup, tenéis un ejemplo en parking.

**Importante**: los errores de los test de parking son debido a la conexión con el websocket y redis. Todo funciona correctamente