### PR TITLE
Arreglo de bugs de validación para las reviews y bookings

### DIFF
--- a/apps/booking/models.py
+++ b/apps/booking/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 import decimal
 from django.db import models
 from django.forms import ValidationError
@@ -10,10 +10,18 @@ from apps.garagement.models import Availability, Garage
 from django.core.validators import MaxValueValidator, MinValueValidator
 from decimal import Decimal
 
+
+
+def validate_date_range(value):
+        min_date = date(2000, 1, 1)
+        max_date = date(2199, 12, 31)
+        if value < min_date or value > max_date:
+            raise ValidationError(f'La fecha {value} se sale del rango válido: 2000-01-01 al 2199-12-31')
+
 class Comment(models.Model):
     title = models.TextField(max_length=64, blank=False, null=False)
     description = models.TextField(max_length=1024)
-    publication_date = models.DateField(auto_now_add=True, blank=False, null=False)
+    publication_date = models.DateField(auto_now_add=True, blank=False, null=False, validators=[validate_date_range])
     rating = models.PositiveIntegerField(validators=[MaxValueValidator(5), MinValueValidator(1)], blank=False, null=False)
     user = models.ForeignKey(CustomUser, on_delete=models.CASCADE, blank=False, null=False)
     garage = models.ForeignKey(Garage, on_delete=models.CASCADE, blank=False, null=False, related_name='comments')

--- a/apps/booking/serializers.py
+++ b/apps/booking/serializers.py
@@ -1,6 +1,6 @@
 from apps.authentication.models import CustomUser
 from apps.booking.enums import BookingStatus, PaymentMethod
-from apps.booking.models import Book
+from apps.booking.models import Book, Comment
 from apps.garagement.enums import GarageStatus
 from apps.garagement.serializers import AvailabilitySerializer, GarageSerializer
 from . import validations
@@ -33,3 +33,11 @@ class BookSerializer(serializers.ModelSerializer):
 
         booking = Book.objects.create(availability=availability, **validated_data)
         return booking
+    
+class CommentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = '__all__'
+
+    def validate(self, attrs):
+        return attrs

--- a/apps/booking/views.py
+++ b/apps/booking/views.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import status
@@ -5,11 +6,12 @@ from rest_framework.response import Response
 
 from apps.garagement.models import Garage
 from .models import Book, Availability
-from .serializers import BookSerializer
+from .serializers import BookSerializer, CommentSerializer
 from django.shortcuts import get_object_or_404
 from apps.garagement.enums import GarageStatus
 from apps.booking.enums import BookingStatus
 from rest_framework.exceptions import ValidationError
+from django.utils.timezone import make_aware
 
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
@@ -57,3 +59,27 @@ def booking_details(request, pk):
             return Response(status=status.HTTP_204_NO_CONTENT)
     except Book.DoesNotExist:
         return Response({"message": "No se encontró ninguna reserva para el garaje."}, status=status.HTTP_404_NOT_FOUND)
+    
+    
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def create_comment(request):
+    garage_id = request.data.get('garage_id')
+    user = request.user
+
+    finished_bookings = Book.objects.filter(
+        user=user,
+        availability__garage_id=garage_id,
+        availability__end_date__lt=make_aware(datetime.now()),
+        status=BookingStatus.CONFIRMED.value
+    )
+
+    if not finished_bookings.exists():
+        return Response({'error': 'No se encontraron reservas confirmadas y finalizadas para este garaje por el usuario.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    comment_serializer = CommentSerializer(data=request.data)
+    if comment_serializer.is_valid():
+        comment_serializer.save(user=user, garage_id=garage_id)
+        return Response(comment_serializer.data, status=status.HTTP_201_CREATED)
+    else:
+        return Response(comment_serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Haciendo los tests de las reviews, me di cuenta de que se podía crear una crítica para una reserva a la cual ya se había realizado una crítica. Adicionalmente, he protegido al atributo publish_date para que no pueda considerarse fechas muy extremistas como antes del año 2000 y después del año 2200. También se ha negado la creación a aquellas disponibilidades que ya hayan sido reservadas previamente.