### PR TITLE
fix: estado de las cesiones en el mapa

### DIFF
--- a/Populate.json
+++ b/Populate.json
@@ -180,7 +180,8 @@
             "is_transfer": true,
             "parking_type": "FREE",
             "created_at": "2022-04-09T00:00:00Z",
-            "updated_at": "2022-04-10T00:00:00Z"
+            "updated_at": "2022-04-10T00:00:00Z",
+            "cesion_parking": "2025-04-10T00:00:00Z"
         }
     },
     {
@@ -195,7 +196,8 @@
             "is_transfer": true,
             "parking_type": "ASSIGNMENT",
             "created_at": "2022-11-26T00:00:00Z",
-            "updated_at": "2022-11-27T00:00:00Z"
+            "updated_at": "2022-11-27T00:00:00Z",
+            "cesion_parking": "2025-07-10T00:00:00Z"
         }
     },
     {
@@ -210,7 +212,8 @@
             "is_transfer": true,
             "parking_type": "ASSIGNMENT",
             "created_at": "2023-08-12T00:00:00Z",
-            "updated_at": "2023-08-13T00:00:00Z"
+            "updated_at": "2023-08-13T00:00:00Z",
+            "cesion_parking": "2025-02-10T00:00:00Z"
         }
     },
     {
@@ -225,7 +228,8 @@
             "is_transfer": true,
             "parking_type": "FREE",
             "created_at": "2022-05-13T00:00:00Z",
-            "updated_at": "2022-05-14T00:00:00Z"
+            "updated_at": "2022-05-14T00:00:00Z",
+            "cesion_parking": "2025-01-10T00:00:00Z"
         }
     },
     {

--- a/apps/parking/views.py
+++ b/apps/parking/views.py
@@ -307,6 +307,7 @@ def postParkingCesion(request: HttpRequest):
         vehicle= Vehicle.objects.get(owner=user.id,principalCar=True)
         parking.booked_by=user
         parking.vehiculo=vehicle
+        parking.is_assignment=True
         parking.save()
         return Response({'id': parking.id}, status=status.HTTP_200_OK)
     except Exception as e:


### PR DESCRIPTION
En esta pull se ha procedido a:

- Solucionar error para poder darle al botón
- Añadida restricción mediante la cual no te deja seleccionar fechas anteriores a la actual
- Solucionado error en el cual no cambiaba el de la cesion en el mapa a pesar de haber sido ocupada
![Captura de pantalla 2024-05-12 231514](https://github.com/Aparking/AparKing_Backend/assets/73081268/c9c0f782-1832-4d2d-ab9a-baf5c178071e)
![Captura de pantalla 2024-05-12 231525](https://github.com/Aparking/AparKing_Backend/assets/73081268/9e141d60-5d70-4e3a-96be-09e4d2146845)
